### PR TITLE
Add 'extern' keyword to hidrd_natv_sink.

### DIFF
--- a/include/hidrd/fmt/natv/snk.h
+++ b/include/hidrd/fmt/natv/snk.h
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 /** Native sink type */
-const hidrd_snk_type    hidrd_natv_snk;
+extern const hidrd_snk_type hidrd_natv_snk;
 
 /** Native sink error code */
 typedef enum hidrd_natv_snk_err {


### PR DESCRIPTION
Otherwise the 'const' keyword gives it wonky linkage.  With this change,
hidrd_natv_sink matches hidrd_natv_src.