### PR TITLE
Fix usage compare

### DIFF
--- a/lib/fmt/hidrd_read_test
+++ b/lib/fmt/hidrd_read_test
@@ -39,9 +39,9 @@ function run ()
     local input="$1"; shift
     local output="$1"; shift
     local output_basename="`basename \"$output\"`"
-    local test_output="`tempfile -s\"_$output_basename.test\"`"
-    local txt_output="`tempfile -s\"_$output_basename.txt\"`"
-    local test_txt_output="`tempfile -s\"_$output_basename.txt.test\"`"
+    local test_output="`mktemp --suffix=\"_$output_basename.test\"`"
+    local txt_output="`mktemp --suffix=\"_$output_basename.txt\"`"
+    local test_txt_output="`mktemp --suffix=\"_$output_basename.txt.test\"`"
     local status
 
     echo "Checking \"$format\" reading from \"$input\"" \

--- a/lib/fmt/hidrd_write_test
+++ b/lib/fmt/hidrd_write_test
@@ -34,7 +34,7 @@ function run ()
     local input="$1"; shift
     local output="$1"; shift
     local output_basename="`basename \"$output\"`"
-    local test_output="`tempfile -s\"_$output_basename.test\"`"
+    local test_output="`mktemp --suffix=\"_$output_basename.test\"`"
     local status
 
     echo "Checking \"$format\" writing of \"$input\"" \

--- a/lib/usage/all.c.m4
+++ b/lib/usage/all.c.m4
@@ -95,10 +95,11 @@ lookup_id_desc(hidrd_usage usage)
 bool
 hidrd_usage_valid(hidrd_usage usage)
 {
-    hidrd_usage min = HIDRD_USAGE_MIN;
-    hidrd_usage max = HIDRD_USAGE_MAX;
+    uint32_t min = (uint32_t)HIDRD_USAGE_MIN;
+    uint32_t max = (uint32_t)HIDRD_USAGE_MAX;
+    uint32_t u = (uint32_t)usage;
 
-    return (usage >= min) && (usage <= max);
+    return (u >= min) && (u <= max);
 }
 
 


### PR DESCRIPTION
As outlined in the second patch, the comparison done by "hidrd_usage_valid" does not work properly if a usage greater than INT32_MAX is defined. This pull request fixes that, as well as updates "make check" (to validate the changes) since the "tempfile" command is long-since deprecated and not available on my system.