### PR TITLE
Fix implicit-fallthrough warning/error in GCC 7

### DIFF
--- a/lib/fmt/xml/snk/element.c
+++ b/lib/fmt/xml/snk/element.c
@@ -227,6 +227,7 @@ xml_snk_element_addpv(hidrd_xml_snk_inst   *xml_snk,
             case XML_SNK_ELEMENT_NT_ATTR:
                 /* Retrieve name */
                 (void)va_arg(*pap, const char *);
+                /* FALLTHROUGH */
             case XML_SNK_ELEMENT_NT_COMMENT:
             case XML_SNK_ELEMENT_NT_CONTENT:
                 fmt =  va_arg(*pap, hidrd_fmt_type);


### PR DESCRIPTION
GCC 7 now warns about implicit fallthrough, causing the build to fail
(due to -Werror) when compiling lib/fmt/xml/snk/element.c.

element.c: In function ‘xml_snk_element_addpv’:
element.c:229:17: error: this statement may fall through [-Werror=implicit-fallthrough=]
                 (void)va_arg(*pap, const char *);
                 ^
element.c:230:13: note: here
             case XML_SNK_ELEMENT_NT_COMMENT:
             ^~~~