### PR TITLE
Fix truncation warning/error in GCC 7

### DIFF
--- a/lib/fmt/xml/src/element_bitmap.c
+++ b/lib/fmt/xml/src/element_bitmap.c
@@ -64,7 +64,7 @@ static bool parse_bitmap_element(uint32_t                  *pbitmap,
     bool        data;
     bool        matched;
     size_t      i;
-    char        i_name[6]   = "bit";
+    char        i_name[24]   = "bit";
 
     for (i = 0, e = e->children; e != NULL; e = e->next)
     {


### PR DESCRIPTION
GCC 7 now warns about potential truncation in printf statements, causing
the build to fail (due to -Werror). Expand the size of our temporary
buffer to make GCC happy.

element_bitmap.c: In function ‘parse_bitmap_element.isra.0’:
element_bitmap.c:96:59: error: ‘%zu’ directive output may be truncated writing between 1 and 20 bytes into a region of size 3 [-Werror=format-truncation=]
                 snprintf(i_name + 3, sizeof(i_name) - 3, "%zu", i);
                                                           ^~~
element_bitmap.c:96:58: note: directive argument in the range [0, 18446744073709551614]
                 snprintf(i_name + 3, sizeof(i_name) - 3, "%zu", i);
                                                          ^~~~~
element_bitmap.c:96:17: note: ‘snprintf’ output between 2 and 21 bytes into a destination of size 3
                 snprintf(i_name + 3, sizeof(i_name) - 3, "%zu", i);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~