### PR TITLE
Digitizer updates

### DIFF
--- a/db/usage/id_digitizer.m4
+++ b/db/usage/id_digitizer.m4
@@ -97,3 +97,17 @@ ID(`0082', `err_normal_status',           `Sel',  `err normal status')dnl
 ID(`0083', `err_transducers_exceeded',    `Sel',  `err transducers exceeded')dnl
 ID(`0084', `err_full_trans_ft_unavail',   `Sel',  `err full transducer features unavailable')dnl
 ID(`0085', `err_charge_low',              `Sel',  `err charge low')dnl
+ID(`0090', `transducer_software_info',    `CL',   `transducer software info')dnl
+ID(`0091', `transducer_vendor_id',        `SV',   `transducer vendor id')dnl
+ID(`0092', `transducer_product_id',       `SV',   `transducer product id')dnl
+ID(`0093', `device_support_protos',       `NAry,CL', `device supported protocols')dnl
+ID(`0094', `transducer_support_protos',   `NAry,CL', `transducer supported protocols')dnl
+ID(`0095', `no_protocol',                 `Sel',  `no protocol')dnl
+ID(`0096', `wacom_aes_protocol',          `Sel',  `wacom aes protocol')dnl
+ID(`0097', `usi_protocol',                `Sel',  `usi protocol')dnl
+ID(`00a0', `supported_report_rates',      `SV,CL', `supported report rates')dnl
+ID(`00a1', `report_rate',                 `DV',   `report rate')dnl
+ID(`00a2', `transducer_connected',        `SF',   `transducer connected')dnl
+ID(`00a3', `switch_disabled',             `Sel',  `switch disabled')dnl
+ID(`00a4', `switch_unimplemented',        `Sel',  `switch unimplemented')dnl
+ID(`00a5', `transducer_switches',         `CL',   `transducer switches')dnl

--- a/db/usage/id_digitizer.m4
+++ b/db/usage/id_digitizer.m4
@@ -42,7 +42,7 @@ ID(`000C', `multipoint_digitizer',        `CA',   `multiple point digitizer')dnl
 ID(`000D', `free_space_wand',             `CA',   `free space wand')dnl
 ID(`000E', `configuration',               `CA',   `configuration')dnl
 ID(`000F', `capacitive_hm_digitizer',     `CA',   `capacitive heat map digitizer')dnl
-ID(`0020', `stylus',                      `CL',   `stylus')dnl
+ID(`0020', `stylus',                      `CA,CL',`stylus')dnl
 ID(`0021', `puck',                        `CL',   `puck')dnl
 ID(`0022', `finger',                      `CL',   `finger')dnl
 ID(`0023', `device_settings',             `CL',   `device settings')dnl
@@ -124,6 +124,7 @@ ID(`0094', `transducer_support_protos',   `NAry,CL', `transducer supported proto
 ID(`0095', `no_protocol',                 `Sel',  `no protocol')dnl
 ID(`0096', `wacom_aes_protocol',          `Sel',  `wacom aes protocol')dnl
 ID(`0097', `usi_protocol',                `Sel',  `usi protocol')dnl
+ID(`0098', `microsoft_pen_protocol',      `Sel',  `microsoft pen protocol')dnl
 ID(`00a0', `supported_report_rates',      `SV,CL', `supported report rates')dnl
 ID(`00a1', `report_rate',                 `DV',   `report rate')dnl
 ID(`00a2', `transducer_connected',        `SF',   `transducer connected')dnl

--- a/db/usage/id_digitizer.m4
+++ b/db/usage/id_digitizer.m4
@@ -45,6 +45,7 @@ ID(`0020', `stylus',                      `CL',   `stylus')dnl
 ID(`0021', `puck',                        `CL',   `puck')dnl
 ID(`0022', `finger',                      `CL',   `finger')dnl
 ID(`0023', `device_settings',             `CL',   `device settings')dnl
+ID(`0024', `character_gesture',           `CL',   `character gesture')dnl
 ID(`0030', `tip_pressure',                `DV',   `tip pressure')dnl
 ID(`0031', `barrel_pressure',             `DV',   `barrel pressure')dnl
 ID(`0032', `in_range',                    `MC',   `in range')dnl
@@ -83,6 +84,16 @@ ID(`005C', `preferred_color',             `DV',   `preferred color')dnl
 ID(`005D', `preferred_color_locked',      `MC',   `preferred color is locked')dnl
 ID(`005E', `preferred_line_width',        `DV',   `preferred line width')dnl
 ID(`005F', `preferred_line_width_locked', `MC',   `preferred line width is locked')dnl
+ID(`0061', `gesture_char_quality',        `DV',   `gesture character quality')dnl
+ID(`0062', `char_gesture_data_len',       `DV',   `character gesture data length')dnl
+ID(`0063', `char_gesture_data',           `DV',   `character gesture data')dnl
+ID(`0064', `gesture_char_encoding',       `NAry', `gesture character encoding')dnl
+ID(`0065', `utf8_char_gesture_enc',       `Sel',  `utf8 character gesture encoding')dnl
+ID(`0066', `utf16le_char_gesture_enc',    `Sel',  `utf16 little endian character gesture encoding')dnl
+ID(`0067', `utf16be_char_gesture_enc',    `Sel',  `utf16 big endian character gesture encoding')dnl
+ID(`0068', `utf32le_char_gesture_enc',    `Sel',  `utf32 little endian character gesture encoding')dnl
+ID(`0069', `utf32be_char_gesture_enc',    `Sel',  `utf32 big endian character gesture encoding')dnl
+ID(`006A', `gesture_char_enable',         `DF',   `gesture character enable')dnl
 ID(`0070', `preferred_line_style',        `NAry', `preferred line style')dnl
 ID(`0071', `preferred_line_style_locked', `MC',   `preferred line style is locked')dnl
 ID(`0072', `ink',                         `Sel',  `ink')dnl

--- a/db/usage/id_digitizer.m4
+++ b/db/usage/id_digitizer.m4
@@ -41,6 +41,7 @@ ID(`000B', `armature',                    `CA',   `armature')dnl
 ID(`000C', `multipoint_digitizer',        `CA',   `multiple point digitizer')dnl
 ID(`000D', `free_space_wand',             `CA',   `free space wand')dnl
 ID(`000E', `configuration',               `CA',   `configuration')dnl
+ID(`000F', `capacitive_hm_digitizer',     `CA',   `capacitive heat map digitizer')dnl
 ID(`0020', `stylus',                      `CL',   `stylus')dnl
 ID(`0021', `puck',                        `CL',   `puck')dnl
 ID(`0022', `finger',                      `CL',   `finger')dnl
@@ -97,7 +98,10 @@ ID(`0066', `utf16le_char_gesture_enc',    `Sel',  `utf16 little endian character
 ID(`0067', `utf16be_char_gesture_enc',    `Sel',  `utf16 big endian character gesture encoding')dnl
 ID(`0068', `utf32le_char_gesture_enc',    `Sel',  `utf32 little endian character gesture encoding')dnl
 ID(`0069', `utf32be_char_gesture_enc',    `Sel',  `utf32 big endian character gesture encoding')dnl
-ID(`006A', `gesture_char_enable',         `DF',   `gesture character enable')dnl
+dnl NOTE: Usage 006A Currently in conflict with HUTRR87 "Capacitive Heat Map Protocol Vendor ID"
+ID(`006A', `gesture_char_enable',         `DF',   `gesture character enable')
+ID(`006B', `capacitive_hm_proto_ver',     `SV',   `capacitive heat map protocol version')dnl
+ID(`006C', `capacitive_hm_frame_data',    `DV',   `capacitive heat map frame data')dnl
 ID(`0070', `preferred_line_style',        `NAry', `preferred line style')dnl
 ID(`0071', `preferred_line_style_locked', `MC',   `preferred line style is locked')dnl
 ID(`0072', `ink',                         `Sel',  `ink')dnl

--- a/db/usage/id_digitizer.m4
+++ b/db/usage/id_digitizer.m4
@@ -78,12 +78,16 @@ ID(`0053', `device_identifier',           `DV',   `device identifier')dnl
 ID(`0054', `contact_count',               `DV',   `contact count')dnl
 ID(`0055', `contact_count_maximum',       `SV',   `contact count maximum')dnl
 ID(`0056', `scan_time',                   `DV',   `scan time')dnl
+ID(`0057', `surface_switch',              `DF',   `surface switch')dnl
+ID(`0058', `button_switch',               `DF',   `button switch')dnl
+ID(`0059', `pad_type',                    `SF',   `pad type')dnl
 ID(`005A', `secondary_barrel_switch',     `MC',   `secondary barrel switch')dnl
 ID(`005B', `transducer_serial_number',    `SV',   `transducer serial number')dnl
 ID(`005C', `preferred_color',             `DV',   `preferred color')dnl
 ID(`005D', `preferred_color_locked',      `MC',   `preferred color is locked')dnl
 ID(`005E', `preferred_line_width',        `DV',   `preferred line width')dnl
 ID(`005F', `preferred_line_width_locked', `MC',   `preferred line width is locked')dnl
+ID(`0060', `latency_mode',                `DF',   `latency mode')dnl
 ID(`0061', `gesture_char_quality',        `DV',   `gesture character quality')dnl
 ID(`0062', `char_gesture_data_len',       `DV',   `character gesture data length')dnl
 ID(`0063', `char_gesture_data',           `DV',   `character gesture data')dnl

--- a/db/usage/id_set_range_digitizer.m4
+++ b/db/usage/id_set_range_digitizer.m4
@@ -33,10 +33,10 @@ dnl     * Set token (non-capitalized, underscores for spaces)
 dnl     * Minimum hexadecimal usage ID (four digits, uppercase)
 dnl     * Maximum hexadecimal usage ID (four digits, uppercase)
 dnl
-ID_SET_RANGE(`reserved',    `000F', `001F')dnl
+ID_SET_RANGE(`reserved',    `0010', `001F')dnl
 ID_SET_RANGE(`reserved',    `0025', `002F')dnl
 ID_SET_RANGE(`reserved',    `004A', `0050')dnl
-ID_SET_RANGE(`reserved',    `006B', `006F')dnl
+ID_SET_RANGE(`reserved',    `006D', `006F')dnl
 ID_SET_RANGE(`reserved',    `0078', `007F')dnl
 ID_SET_RANGE(`reserved',    `0086', `008F')dnl
 ID_SET_RANGE(`reserved',    `0098', `009F')dnl

--- a/db/usage/id_set_range_digitizer.m4
+++ b/db/usage/id_set_range_digitizer.m4
@@ -34,10 +34,11 @@ dnl     * Minimum hexadecimal usage ID (four digits, uppercase)
 dnl     * Maximum hexadecimal usage ID (four digits, uppercase)
 dnl
 ID_SET_RANGE(`reserved',    `000F', `001F')dnl
-ID_SET_RANGE(`reserved',    `0024', `002F')dnl
+ID_SET_RANGE(`reserved',    `0025', `002F')dnl
 ID_SET_RANGE(`reserved',    `004A', `0050')dnl
 ID_SET_RANGE(`reserved',    `0057', `0059')dnl
-ID_SET_RANGE(`reserved',    `0060', `006F')dnl
+ID_SET_RANGE(`reserved',    `0060', `0060')dnl
+ID_SET_RANGE(`reserved',    `006B', `006F')dnl
 ID_SET_RANGE(`reserved',    `0078', `007F')dnl
 ID_SET_RANGE(`reserved',    `0086', `008F')dnl
 ID_SET_RANGE(`reserved',    `0098', `009F')dnl

--- a/db/usage/id_set_range_digitizer.m4
+++ b/db/usage/id_set_range_digitizer.m4
@@ -39,4 +39,6 @@ ID_SET_RANGE(`reserved',    `004A', `0050')dnl
 ID_SET_RANGE(`reserved',    `0057', `0059')dnl
 ID_SET_RANGE(`reserved',    `0060', `006F')dnl
 ID_SET_RANGE(`reserved',    `0078', `007F')dnl
-ID_SET_RANGE(`reserved',    `0086', `FFFF')dnl
+ID_SET_RANGE(`reserved',    `0086', `008F')dnl
+ID_SET_RANGE(`reserved',    `0098', `009F')dnl
+ID_SET_RANGE(`reserved',    `00A6', `FFFF')dnl

--- a/db/usage/id_set_range_digitizer.m4
+++ b/db/usage/id_set_range_digitizer.m4
@@ -39,5 +39,5 @@ ID_SET_RANGE(`reserved',    `004A', `0050')dnl
 ID_SET_RANGE(`reserved',    `006D', `006F')dnl
 ID_SET_RANGE(`reserved',    `0078', `007F')dnl
 ID_SET_RANGE(`reserved',    `0086', `008F')dnl
-ID_SET_RANGE(`reserved',    `0098', `009F')dnl
+ID_SET_RANGE(`reserved',    `0099', `009F')dnl
 ID_SET_RANGE(`reserved',    `00A6', `FFFF')dnl

--- a/db/usage/id_set_range_digitizer.m4
+++ b/db/usage/id_set_range_digitizer.m4
@@ -36,8 +36,6 @@ dnl
 ID_SET_RANGE(`reserved',    `000F', `001F')dnl
 ID_SET_RANGE(`reserved',    `0025', `002F')dnl
 ID_SET_RANGE(`reserved',    `004A', `0050')dnl
-ID_SET_RANGE(`reserved',    `0057', `0059')dnl
-ID_SET_RANGE(`reserved',    `0060', `0060')dnl
 ID_SET_RANGE(`reserved',    `006B', `006F')dnl
 ID_SET_RANGE(`reserved',    `0078', `007F')dnl
 ID_SET_RANGE(`reserved',    `0086', `008F')dnl

--- a/lib/fmt/write_test_data/collection.spec
+++ b/lib/fmt/write_test_data/collection.spec
@@ -2,7 +2,7 @@ Usage Page (Digitizer),     ; Digitizer (0Dh)
 Usage (Pen),                ; Pen (02h, application collection)
 Collection (Application),
     Report ID (7),
-    Usage (Stylus),         ; Stylus (20h, logical collection)
+    Usage (Stylus),         ; Stylus (20h, application collection, logical collection)
     Collection (Physical),
         Usage (Tip Switch), ; Tip switch (42h, momentary control)
     End Collection,

--- a/lib/fmt/write_test_data/collection.xml
+++ b/lib/fmt/write_test_data/collection.xml
@@ -4,7 +4,7 @@
   <usage>digitizer_pen<!-- Pen (02h, application collection) --></usage>
   <COLLECTION type="application">
     <report_id>7</report_id>
-    <usage>digitizer_stylus<!-- Stylus (20h, logical collection) --></usage>
+    <usage>digitizer_stylus<!-- Stylus (20h, application collection, logical collection) --></usage>
     <COLLECTION type="physical">
       <usage>digitizer_tip_switch<!-- Tip switch (42h, momentary control) --></usage>
     </COLLECTION>

--- a/lib/usage/type.c
+++ b/lib/usage/type.c
@@ -131,7 +131,7 @@ hidrd_usage_type_set_desc_str(hidrd_usage_type_set set)
                 if (new_str == NULL)
                     goto failure;
             }
-            else if (asprintf(&new_str, "%s, %s", str, new_str) < 0)
+            else if (asprintf(&new_str, "%s, %s", str, hidrd_usage_type_idx_name(i)) < 0)
                 goto failure;
             free(str);
             str = new_str;


### PR DESCRIPTION
Merge in changes to the Digitizer page from HID review requests 67, 76, 83, 87, and 88.

Note that requests 76 and 87 are currently in conflict over the definition of usage 0x6A. This will hopefully be resolved soon.

EDIT: Noticed that changes for request 88 broke the test suite. Changed the tests's expected output and also added a commit that fixes a bug in the generation of type descriptions.