### PR TITLE
Allocate hex map with the trailing NULL

### DIFF
--- a/lib/util/hex.c
+++ b/lib/util/hex.c
@@ -84,7 +84,7 @@ hidrd_hex_buf_from_str(void        *buf,
 char *
 hidrd_hex_buf_to_str(const void *buf, size_t size)
 {
-    static const char   map[16] = "0123456789ABCDEF";
+    static const char   map[17] = "0123456789ABCDEF";
     const uint8_t      *bbuf    = (const uint8_t *)buf;
     char               *str;
     char               *p;


### PR DESCRIPTION
Compilers usually warns or errors on such allocations. This would require special compiler parameter or attribute to silence it. Unfortunately, it is compiler specific, e.g. with gcc one could use "__attribute__ ((nonstring))" or with C23 just "[[nonstring]]" or gcc parameter
"-Wno-error=unterminated-string-initialization". With other compilers it's different. So do not over-complicate things and allocate it just one more byte longer with the dummy NULL which should silence most of the compilers. It's static allocation, just one byte, the overhead should be negligible.